### PR TITLE
add accessors for PmDeviceInfo input & output

### DIFF
--- a/src/midi.rs
+++ b/src/midi.rs
@@ -217,6 +217,14 @@ impl PmDeviceInfo {
             opened : self.opened as i32,
         }
     }
+
+    pub fn is_input(&self) -> bool {
+        self.input > 0
+    }
+
+    pub fn is_output(&self) -> bool {
+        self.output > 0
+    }
 }
 
 /**  Get devices count, ids range from 0 to Pm_CountDevices()-1. */


### PR DESCRIPTION
I've added accessors for `PmDeviceInfo.input` and `PmDeviceInfo.ouput` as I needed to access that information, but I didn't want to allow it be modified.

We could also add a `is_opened` accessor too.
