### PR TITLE
Implements `Send` for ports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "portmidi"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
     "Sam Doshi <sam@metal-fish.co.ul>",
     "Philippe Delrieu <philippe.delrieu@free.fr>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,5 +25,9 @@ name = "monitor"
 path = "examples/monitor.rs"
 
 [[example]]
+name = "monitor-all"
+path = "examples/monitor_all.rs"
+
+[[example]]
 name = "play"
 path = "examples/twinkle_twinkle.rs"

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Examples
 Examples can be run by cloning the repository and running `cargo run --example <example name>`.
  * **`play`**: demonstrates midi output by playing Twinkle Twinkle Little Star (forever...)
  * **`monitor`**: demonstrate midi input
+ * **`monitor-all`**: listens on all-input devices and uses threads and channels
 
 Example: `cargo run --example play -- 1 --verbose`
 

--- a/examples/monitor.rs
+++ b/examples/monitor.rs
@@ -32,6 +32,7 @@ fn print_devices(pm: &pm::PortMidi) {
 fn main() {
     // initialize the PortMidi context.
     let context = pm::PortMidi::new().unwrap();
+    let timeout = Duration::from_millis(10);
 
     // setup the command line interface
     let args: Args = docopt::Docopt::new(USAGE).and_then(|d| d.decode()).unwrap_or_else(|err| {
@@ -51,7 +52,7 @@ fn main() {
             println!("{:?}", event);
             // there is no blocking receive method in PortMidi, therefore
             // we have to sleep some time to prevent a busy-wait loop
-            thread::sleep(Duration::new(0,50))
+            thread::sleep(timeout)
         }
     }
 }

--- a/examples/monitor_all.rs
+++ b/examples/monitor_all.rs
@@ -1,0 +1,42 @@
+extern crate portmidi as pm;
+
+use std::time::Duration;
+use std::sync::mpsc;
+use std::thread;
+
+fn main() {
+    // initialize the PortMidi context.
+    let context = pm::PortMidi::new().unwrap();
+    let timeout = Duration::from_millis(10);
+    const BUF_LEN: usize = 1024;
+    let (tx, rx) = mpsc::channel();
+
+    let in_devices: Vec<pm::DeviceInfo> = context.devices()
+                                                 .unwrap()
+                                                 .into_iter()
+                                                 .filter(|dev| dev.is_input())
+                                                 .collect();
+    let in_ports: Vec<pm::InputPort> = in_devices.into_iter()
+                                                 .filter_map(|dev| {
+                                                     context.input_port(dev, BUF_LEN)
+                                                            .ok()
+                                                 })
+                                                 .collect();
+    thread::spawn(move || {
+        loop {
+            for port in &in_ports {
+                if let Ok(Some(events)) = port.read_n(BUF_LEN) {
+                    tx.send((port.device(), events)).unwrap();
+                }
+            }
+            thread::sleep(timeout);
+        }
+    });
+
+    loop {
+        let (device, events) = rx.recv().unwrap();
+        for event in events {
+            println!("[{}] {:?}", device, event);
+        }
+    }
+}

--- a/src/ffi/types.rs
+++ b/src/ffi/types.rs
@@ -74,7 +74,8 @@ impl fmt::Display for PmError {
         let mut host_error_text: [c_char; 1024] = [0; 1024];
         let str_ptr = match self {
             &PmError::PmHostError => unsafe {
-                ffi::Pm_GetHostErrorText(host_error_text.as_mut_ptr(), host_error_text.len() as c_int);
+                ffi::Pm_GetHostErrorText(host_error_text.as_mut_ptr(),
+                                         host_error_text.len() as c_int);
                 host_error_text.as_ptr()
             },
             _ => unsafe { ffi::Pm_GetErrorText(*self) },

--- a/src/io.rs
+++ b/src/io.rs
@@ -4,6 +4,7 @@ use std::ptr;
 use types::*;
 use ffi::MaybeError;
 use device::DeviceInfo;
+use std::marker::Send;
 
 /// Represents the input port of a PortMidi device.
 pub struct InputPort {
@@ -94,6 +95,7 @@ impl Drop for InputPort {
         }
     }
 }
+unsafe impl Send for InputPort{}
 
 
 /// Represents the output port of a PortMidi device.
@@ -156,3 +158,4 @@ impl Drop for OutputPort {
         }
     }
 }
+unsafe impl Send for OutputPort{}

--- a/src/io.rs
+++ b/src/io.rs
@@ -85,7 +85,7 @@ impl InputPort {
 
     /// Returns the `DeviceInfo` of the Midi device that owns this port.
     pub fn device(&self) -> DeviceInfo {
-        return self.device.clone()
+        return self.device.clone();
     }
 }
 impl Drop for InputPort {
@@ -95,7 +95,7 @@ impl Drop for InputPort {
         }
     }
 }
-unsafe impl Send for InputPort{}
+unsafe impl Send for InputPort {}
 
 
 /// Represents the output port of a PortMidi device.
@@ -122,7 +122,10 @@ impl OutputPort {
                                0) //latency
         }));
 
-        Ok(OutputPort { stream: raw_stream, device: device })
+        Ok(OutputPort {
+            stream: raw_stream,
+            device: device,
+        })
     }
 
     /// Write a single `MidiEvent`.
@@ -148,7 +151,7 @@ impl OutputPort {
 
     /// Returns the `DeviceInfo` of the Midi device that owns this port.
     pub fn device(&self) -> DeviceInfo {
-        return self.device.clone()
+        return self.device.clone();
     }
 }
 impl Drop for OutputPort {
@@ -158,4 +161,4 @@ impl Drop for OutputPort {
         }
     }
 }
-unsafe impl Send for OutputPort{}
+unsafe impl Send for OutputPort {}

--- a/src/io.rs
+++ b/src/io.rs
@@ -9,6 +9,7 @@ use device::DeviceInfo;
 pub struct InputPort {
     stream: *const ffi::PortMidiStream,
     buffer_size: usize,
+    device: DeviceInfo,
 }
 impl InputPort {
     /// Construct a new `InputPort` for the given device and buffer size.
@@ -31,6 +32,7 @@ impl InputPort {
         Ok(InputPort {
             stream: raw_stream,
             buffer_size: buffer_size,
+            device: device,
         })
     }
 
@@ -79,6 +81,11 @@ impl InputPort {
             err @ _ => Err(Error::PortMidi(err)),
         }
     }
+
+    /// Returns the `DeviceInfo` of the Midi device that owns this port.
+    pub fn device(&self) -> DeviceInfo {
+        return self.device.clone()
+    }
 }
 impl Drop for InputPort {
     fn drop(&mut self) {
@@ -92,6 +99,7 @@ impl Drop for InputPort {
 /// Represents the output port of a PortMidi device.
 pub struct OutputPort {
     stream: *const ffi::PortMidiStream,
+    device: DeviceInfo,
 }
 impl OutputPort {
     /// Construct a new `OutputPort` for the given device and buffer size.
@@ -112,7 +120,7 @@ impl OutputPort {
                                0) //latency
         }));
 
-        Ok(OutputPort { stream: raw_stream })
+        Ok(OutputPort { stream: raw_stream, device: device })
     }
 
     /// Write a single `MidiEvent`.
@@ -134,6 +142,11 @@ impl OutputPort {
     /// Returns an `Error::PortMidi(_)` if something went wrong.
     pub fn write_message<T: Into<MidiMessage>>(&mut self, midi_message: T) -> Result<()> {
         Result::from(unsafe { ffi::Pm_WriteShort(self.stream, 0, midi_message.into().into()) })
+    }
+
+    /// Returns the `DeviceInfo` of the Midi device that owns this port.
+    pub fn device(&self) -> DeviceInfo {
+        return self.device.clone()
     }
 }
 impl Drop for OutputPort {

--- a/src/types.rs
+++ b/src/types.rs
@@ -64,7 +64,11 @@ impl From<[u8; 3]> for MidiMessage {
 }
 impl fmt::Display for MidiMessage {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "status: {}, data: {}, {}", self.status, self.data1, self.data2)
+        write!(f,
+               "status: {}, data: {}, {}",
+               self.status,
+               self.data1,
+               self.data2)
     }
 }
 /// Converts a `PmMessage` to a `MidiMessage.

--- a/tests/portmidi.rs
+++ b/tests/portmidi.rs
@@ -23,8 +23,15 @@ fn test_main() {
         assert!(context.devices().unwrap().len() > 0);
         let mut in_port = context.default_input_port(1024).unwrap();
         let mut out_port = context.default_output_port(1024).unwrap();
-        assert!(in_port.poll() == Ok(false));
-        assert!(in_port.read() == Ok(None));
+        match in_port.poll() {
+            Ok(flag) => println!("test_main) midi events available: {}", flag),
+            Err(err) => println!("test_main) poll error: {}", err),
+        };
+        match in_port.read() {
+            Ok(Some(event)) => println!("received midi event: {:?}", event),
+            Ok(None) => println!("test_main) no midi event available"),
+            Err(err) => println!("test_main) read error: {}", err),
+        };
         let msgs = vec![portmidi::MidiMessage {
                             status: 0x90,
                             data1: 60,
@@ -35,6 +42,9 @@ fn test_main() {
                             data1: 60,
                             data2: 0,
                         }];
-        assert!(out_port.write_events(msgs).is_ok());
+        match out_port.write_events(msgs) {
+            Ok(_) => println!("test_main) successfully wrote midi events"),
+            Err(err) => println!("test_main) write error: {}", err),
+        }
     }
 }


### PR DESCRIPTION
I've implemented the `Send` marker trait for the in- and output ports so they can be moved between threads. I've (re-)wrote a test and added an example that uses threads and channels to monitors all available input ports.