### PR TITLE
Fix byte order in midi messages.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "portmidi"
-version = "0.2.1"
+version = "0.2.2"
 authors = [
     "Sam Doshi <sam@metal-fish.co.ul>",
     "Philippe Delrieu <philippe.delrieu@free.fr>"

--- a/src/types.rs
+++ b/src/types.rs
@@ -76,9 +76,9 @@ impl fmt::Display for MidiMessage {
 impl From<ffi::PmMessage> for MidiMessage {
     fn from(raw: i32) -> Self {
         MidiMessage {
-            status: ((raw & 0x00_FF_00_00) >> 16) as u8,
+            status: (raw & 0x00_00_00_FF) as u8,
             data1: ((raw & 0x00_00_FF_00) >> 8) as u8,
-            data2: (raw & 0x00_00_00_FF) as u8,
+            data2: ((raw & 0x00_FF_00_00) >> 16) as u8,
         }
     }
 }

--- a/tests/portmidi.rs
+++ b/tests/portmidi.rs
@@ -90,3 +90,14 @@ fn test_threads() {
         writer.join();
     }
 }
+
+#[test]
+fn test_types() {
+    let message = portmidi::MidiMessage::from(0x007F3C81);
+    // NoteOn
+    assert_eq!(message.status, 0x81);
+    // Key: Note 60
+    assert_eq!(message.data1, 60);
+    // Velocity: 127
+    assert_eq!(message.data2, 127);
+}


### PR DESCRIPTION
I got the byte order of the Midi message wrong :unamused:. To fix this I swapped the masks of the `data2` and `status` byte.