### PR TITLE
Add basic wrapper for sysex write

### DIFF
--- a/src/ffi/functions.rs
+++ b/src/ffi/functions.rs
@@ -6,7 +6,7 @@
 //          MIT license (LICENSE-MIT or http://opensource.org/licenses/MIT).
 // This file may not be copied, modified, or distributed except according to those terms.
 
-use std::os::raw::{c_char, c_void, c_int};
+use std::os::raw::{c_char, c_void, c_int, c_uchar};
 use ffi::types::*;
 
 #[allow(dead_code)]
@@ -47,5 +47,9 @@ extern "C" {
     pub fn Pm_WriteShort(stream: *const PortMidiStream,
                          timestamp: PmTimestamp,
                          message: PmMessage)
+                         -> PmError;
+    pub fn Pm_WriteSysEx(stream: *const PortMidiStream,
+                         when: PmTimestamp,
+                         msg: *const c_uchar)
                          -> PmError;
 }

--- a/src/ffi/types.rs
+++ b/src/ffi/types.rs
@@ -10,6 +10,7 @@ pub type PmMessage = c_int;
 
 pub type PmTimestamp = u32;
 pub const PM_NO_DEVICE: PmDeviceId = -1;
+pub const MIDI_EOX: u8 = 0xf7;
 
 #[derive(Copy, Clone, Debug)]
 #[repr(C)]

--- a/src/io.rs
+++ b/src/io.rs
@@ -153,6 +153,16 @@ impl OutputPort {
     pub fn device(&self) -> DeviceInfo {
         return self.device.clone();
     }
+
+    // Write arbitrarily long EOX-terminated data
+    pub fn write_sysex(&self, timestamp: ffi::PmTimestamp, msg: &[u8]) -> Result<()> {
+        // Sysex writes MUST be EOX-terminated
+        if Some(&ffi::MIDI_EOX) != msg.last() {
+            Err(Error::Invalid)
+        } else {
+            Result::from(unsafe { ffi::Pm_WriteSysEx(self.stream, timestamp, msg.as_ptr())})
+        }
+    }
 }
 impl Drop for OutputPort {
     fn drop(&mut self) {


### PR DESCRIPTION
Hey, I added a wrapper for Pm_WriteSysEx. I tested it on my Novation Launchpad, and it works as intended.

I am not very familiar with PortMidi or MIDI in general, so let me know if I am missing something important.

I added a check for the terminator, because looking at the C code here: http://portmedia.sourceforge.net/portmidi/doxygen/portmidi_8c-source.html, it looks like PortMidi will happily write off the edge of the buffer until it hits a terminator.