### PR TITLE
Feature: Creating Virtual Devices on non-Windows systems

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,7 @@ path = "examples/monitor_all.rs"
 [[example]]
 name = "play"
 path = "examples/twinkle_twinkle.rs"
+
+[[example]]
+name = "virtual_devices"
+path = "examples/virtual_devices.rs"

--- a/examples/monitor.rs
+++ b/examples/monitor.rs
@@ -1,10 +1,10 @@
 extern crate portmidi as pm;
 
-extern crate rustc_serialize;
 extern crate docopt;
+extern crate rustc_serialize;
 
-use std::time::Duration;
 use std::thread;
+use std::time::Duration;
 
 const USAGE: &'static str = r#"
 portmidi-rs: monitor-device example
@@ -35,10 +35,12 @@ fn main() {
     let timeout = Duration::from_millis(10);
 
     // setup the command line interface
-    let args: Args = docopt::Docopt::new(USAGE).and_then(|d| d.decode()).unwrap_or_else(|err| {
-        print_devices(&context);
-        err.exit();
-    });
+    let args: Args = docopt::Docopt::new(USAGE)
+        .and_then(|d| d.decode())
+        .unwrap_or_else(|err| {
+            print_devices(&context);
+            err.exit();
+        });
 
     // get the device info for the given id
     let info = context.device(args.arg_device_id).unwrap();

--- a/examples/monitor_all.rs
+++ b/examples/monitor_all.rs
@@ -1,8 +1,8 @@
 extern crate portmidi as pm;
 
-use std::time::Duration;
 use std::sync::mpsc;
 use std::thread;
+use std::time::Duration;
 
 fn main() {
     // initialize the PortMidi context.

--- a/examples/virtual_devices.rs
+++ b/examples/virtual_devices.rs
@@ -1,0 +1,116 @@
+extern crate portmidi as pm;
+
+use std::sync::Arc;
+use std::time::Duration;
+use std::thread;
+use pm::MidiMessage;
+
+static CHANNEL: u8 = 0;
+static MELODY: [(u8, u32); 42] = [
+    (60, 1),
+    (60, 1),
+    (67, 1),
+    (67, 1),
+    (69, 1),
+    (69, 1),
+    (67, 2),
+    (65, 1),
+    (65, 1),
+    (64, 1),
+    (64, 1),
+    (62, 1),
+    (62, 1),
+    (60, 2),
+    (67, 1),
+    (67, 1),
+    (65, 1),
+    (65, 1),
+    (64, 1),
+    (64, 1),
+    (62, 2),
+    (67, 1),
+    (67, 1),
+    (65, 1),
+    (65, 1),
+    (64, 1),
+    (64, 1),
+    (62, 2),
+    (60, 1),
+    (60, 1),
+    (67, 1),
+    (67, 1),
+    (69, 1),
+    (69, 1),
+    (67, 2),
+    (65, 1),
+    (65, 1),
+    (64, 1),
+    (64, 1),
+    (62, 1),
+    (62, 1),
+    (60, 2),
+];
+
+fn main() {
+    // initialize the PortMidi context.
+    let context = pm::PortMidi::new().unwrap();
+    let context = Arc::new(context);
+    let timeout = Duration::from_millis(10);
+
+    let v_in = context.create_virtual_input("Virt In 1".into()).unwrap();
+    let v_out = context.create_virtual_output("Virt Out 1".into()).unwrap();
+
+    println!("Virtual Devices: {:?}", context.virtual_devices().unwrap());
+
+    let con2 = Arc::clone(&context);
+    thread::spawn(move || {
+	let out_port = con2.output_port(v_out, 1024).unwrap();
+	println!("Playing... Connect Virt Out 1 to Virt In 1 to see midi messages on screen...");
+	println!("(Note: Windows not supported: midi devices do have to be implemented drivers)");
+	println!("Press Crtl-C to abort...");
+	play(out_port, false).unwrap();
+    });
+
+    let in_port = context.input_port(v_in, 1024).unwrap();
+
+    while let Ok(_) = in_port.poll() {
+        if let Ok(Some(event)) = in_port.read_n(1024) {
+            println!("{:?}", event);
+        }
+        // there is no blocking receive method in PortMidi, therefore
+        // we have to sleep some time to prevent a busy-wait loop
+        thread::sleep(timeout);
+    }
+}
+
+
+fn play(mut out_port: pm::OutputPort, verbose: bool) -> pm::Result<()> {
+    for &(note, dur) in MELODY.iter().cycle() {
+        let note_on = MidiMessage {
+            status: 0x90 + CHANNEL,
+            data1: note,
+            data2: 100,
+            data3: 0,
+        };
+        if verbose {
+            println!("{}", note_on)
+        }
+        out_port.write_message(note_on)?;
+        // note hold time before sending note off
+        thread::sleep(Duration::from_millis(dur as u64 * 400));
+
+        let note_off = MidiMessage {
+            status: 0x80 + CHANNEL,
+            data1: note,
+            data2: 100,
+            data3: 0,
+        };
+        if verbose {
+            println!("{}", note_off);
+        }
+        out_port.write_message(note_off)?;
+        // short pause
+        thread::sleep(Duration::from_millis(100));
+    }
+    Ok(())
+}

--- a/examples/virtual_devices.rs
+++ b/examples/virtual_devices.rs
@@ -63,14 +63,14 @@ fn main() {
 
     let con2 = Arc::clone(&context);
     thread::spawn(move || {
-        let out_port = con2.output_port(v_out.devinfo().clone(), 1024).unwrap();
+        let out_port = con2.output_port(con2.device(v_out.id()).unwrap(), 1024).unwrap();
         println!("Playing... Connect Virt Out 1 to Virt In 1 to see midi messages on screen...");
         println!("(Note: Windows not supported: midi devices do have to be implemented drivers)");
         println!("Press Crtl-C to abort...");
         play(out_port, false);
     });
 
-    let in_port = context.input_port(v_in.devinfo().clone(), 1024).unwrap();
+    let in_port = context.input_port(context.device(v_in.id()).unwrap(), 1024).unwrap();
 
     while let Ok(_) = in_port.poll() {
         if let Ok(Some(event)) = in_port.read_n(1024) {

--- a/examples/virtual_devices.rs
+++ b/examples/virtual_devices.rs
@@ -57,8 +57,8 @@ fn main() {
     let context = Arc::new(context);
     let timeout = Duration::from_millis(10);
 
-    let v_in = context.create_virtual_input("Virt In 1".into()).unwrap();
-    let v_out = context.create_virtual_output("Virt Out 1".into()).unwrap();
+    let v_in = context.create_virtual_input("Virt In 1").unwrap();
+    let v_out = context.create_virtual_output("Virt Out 1").unwrap();
 
     println!("Virtual Devices: {:?}", context.virtual_devices().unwrap());
 

--- a/examples/virtual_devices.rs
+++ b/examples/virtual_devices.rs
@@ -60,18 +60,17 @@ fn main() {
     let v_in = context.create_virtual_input("Virt In 1").unwrap();
     let v_out = context.create_virtual_output("Virt Out 1").unwrap();
 
-    println!("Virtual Devices: {:?}", context.virtual_devices().unwrap());
 
     let con2 = Arc::clone(&context);
     thread::spawn(move || {
-        let out_port = con2.output_port(v_out, 1024).unwrap();
+        let out_port = con2.output_port(v_out.devinfo().clone(), 1024).unwrap();
         println!("Playing... Connect Virt Out 1 to Virt In 1 to see midi messages on screen...");
         println!("(Note: Windows not supported: midi devices do have to be implemented drivers)");
         println!("Press Crtl-C to abort...");
-        play(out_port, false).unwrap();
+        play(out_port, false);
     });
 
-    let in_port = context.input_port(v_in, 1024).unwrap();
+    let in_port = context.input_port(v_in.devinfo().clone(), 1024).unwrap();
 
     while let Ok(_) = in_port.poll() {
         if let Ok(Some(event)) = in_port.read_n(1024) {

--- a/examples/virtual_devices.rs
+++ b/examples/virtual_devices.rs
@@ -60,17 +60,20 @@ fn main() {
     let v_in = context.create_virtual_input("Virt In 1").unwrap();
     let v_out = context.create_virtual_output("Virt Out 1").unwrap();
 
-
     let con2 = Arc::clone(&context);
     thread::spawn(move || {
-        let out_port = con2.output_port(con2.device(v_out.id()).unwrap(), 1024).unwrap();
+        let out_port = con2
+            .output_port(con2.device(v_out.id()).unwrap(), 1024)
+            .unwrap();
         println!("Playing... Connect Virt Out 1 to Virt In 1 to see midi messages on screen...");
         println!("(Note: Windows not supported: midi devices do have to be implemented drivers)");
         println!("Press Crtl-C to abort...");
         play(out_port, false);
     });
 
-    let in_port = context.input_port(context.device(v_in.id()).unwrap(), 1024).unwrap();
+    let in_port = context
+        .input_port(context.device(v_in.id()).unwrap(), 1024)
+        .unwrap();
 
     while let Ok(_) = in_port.poll() {
         if let Ok(Some(event)) = in_port.read_n(1024) {

--- a/examples/virtual_devices.rs
+++ b/examples/virtual_devices.rs
@@ -1,9 +1,9 @@
 extern crate portmidi as pm;
 
-use std::sync::Arc;
-use std::time::Duration;
-use std::thread;
 use pm::MidiMessage;
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
 
 static CHANNEL: u8 = 0;
 static MELODY: [(u8, u32); 42] = [
@@ -64,11 +64,11 @@ fn main() {
 
     let con2 = Arc::clone(&context);
     thread::spawn(move || {
-	let out_port = con2.output_port(v_out, 1024).unwrap();
-	println!("Playing... Connect Virt Out 1 to Virt In 1 to see midi messages on screen...");
-	println!("(Note: Windows not supported: midi devices do have to be implemented drivers)");
-	println!("Press Crtl-C to abort...");
-	play(out_port, false).unwrap();
+        let out_port = con2.output_port(v_out, 1024).unwrap();
+        println!("Playing... Connect Virt Out 1 to Virt In 1 to see midi messages on screen...");
+        println!("(Note: Windows not supported: midi devices do have to be implemented drivers)");
+        println!("Press Crtl-C to abort...");
+        play(out_port, false).unwrap();
     });
 
     let in_port = context.input_port(v_in, 1024).unwrap();
@@ -82,7 +82,6 @@ fn main() {
         thread::sleep(timeout);
     }
 }
-
 
 fn play(mut out_port: pm::OutputPort, verbose: bool) -> pm::Result<()> {
     for &(note, dur) in MELODY.iter().cycle() {

--- a/src/context.rs
+++ b/src/context.rs
@@ -35,6 +35,10 @@ impl PortMidi {
         self.device_count as c_int
     }
 
+    pub fn virtual_device_count(&self) -> PortMidiDeviceId {
+	self.virtual_devs.len() as c_int
+    }
+
     /// Returns the `PortMidiDeviceId` for the default input device, or an `Error::NoDefaultDevice` if
     /// there is no available.
     pub fn default_input_device_id(&self) -> Result<PortMidiDeviceId> {

--- a/src/context.rs
+++ b/src/context.rs
@@ -134,7 +134,7 @@ impl PortMidi {
 
     /// Creates a virtual input/output device depending on is_input argument.
     /// Returns the device info of the created device or throws an Error.
-    fn create_virtual_device(&self, name: String, is_input: bool) -> Result<DeviceInfo> {
+    fn create_virtual_device(&self, name: &str, is_input: bool) -> Result<DeviceInfo> {
         let c_string = CString::new(name.clone()).unwrap();
         let id;
         if is_input {
@@ -159,13 +159,13 @@ impl PortMidi {
 
     /// Creates a virtual output device for the lifetime of the PortMidi instance.
     /// Returns the device info of the created device or throws an Error.
-    pub fn create_virtual_input(&self, name: String) -> Result<DeviceInfo> {
+    pub fn create_virtual_input(&self, name: &str) -> Result<DeviceInfo> {
         self.create_virtual_device(name, true)
     }
 
     /// Creates a virtual input device for the lifetime of the PortMidi instance.
     /// Returns the device info of the created device or throws an Error.
-    pub fn create_virtual_output(&self, name: String) -> Result<DeviceInfo> {
+    pub fn create_virtual_output(&self, name: &str) -> Result<DeviceInfo> {
         self.create_virtual_device(name, false)
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -169,6 +169,8 @@ impl PortMidi {
         self.create_virtual_device(name, false)
     }
 
+    /// Deletes a virtual device created by this instance.
+    /// Returns Ok(()) or an Error, Error::Unknown when id is not an id of a virtual device.
     pub fn delete_virtual_device(&self, id: PortMidiDeviceId) -> Result<()> {
         let v_dev_vec = &mut (*self.virtual_devs.lock().unwrap());
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -40,6 +40,7 @@ impl PortMidi {
         self.device_count as c_int
     }
 
+    /// Return the number of virtual devices created in this instance.
     pub fn virtual_device_count(&self) -> PortMidiDeviceId {
 	(*self.virtual_devs.lock().unwrap()).len() as c_int
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -120,14 +120,15 @@ impl PortMidi {
 
     // Creates a `VirtualOutput` instance with the given name and ......
     pub fn create_virtual_output(&self, name: String) -> Result<DeviceInfo> {
-    	let c_string = CString::new(name).unwrap();
-    	let id = unsafe { ffi::Pm_CreateVirtualOutput(c_string.as_ptr(), ptr::null(), ptr::null()) };
-    	
+        let c_string = CString::new(name.clone()).unwrap();
+        let id  = unsafe { ffi::Pm_CreateVirtualOutput(c_string.as_ptr(), ptr::null(), ptr::null()) };
+
     	let id = match ffi::PmError::try_from(id as c_int) {
-		Ok(id) => Ok(Some(id)),
-		Err(ffi::PmError::PmNoError) => Ok(None),
-		Err(err) => Err(Error::PortMidi(err)),
-    	}?;
+		Err(ffi::PmError::PmNoError) => None,
+                Err(ffi::PmError::PmInvalidDeviceId) => panic!("Device name \"{}\" already exists or is invalid!", name),
+		Err(err) => return Err(Error::PortMidi(err)),
+		Ok(id) => Some(id),
+        };
 
 	let id: PortMidiDeviceId = id.unwrap();
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -82,6 +82,20 @@ impl PortMidi {
         Ok(devices)
     }
 
+    /// Returns a `Vec<DeviceInfo>` containing all virtual device infos.
+    /// An `Error::PortMidi(_)` is returned if the info for a virtual device can't be obtained.
+    pub fn virtual_devices(&self) -> Result<Vec<DeviceInfo>> {
+	let mut v_devs = Vec::with_capacity(self.virtual_device_count() as usize);
+	let v_dev_vec: &Vec<PortMidiDeviceId> = &self.virtual_devs.lock().unwrap();
+	for res in v_dev_vec.iter().map(|&id| self.device(id)) {
+	    match res {
+		Ok(device) => v_devs.push(device),
+		Err(err) => return Err(err),
+	    }
+	}
+	Ok(v_devs)
+    }
+
     /// Creates an `InputPort` instance with the given buffer size for the default input device.
     pub fn default_input_port(&self, buffer_size: usize) -> Result<InputPort> {
         let info = self

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,9 +1,9 @@
 use device::{DeviceInfo, Direction};
-use vdevice::VirtualDevice;
 use ffi;
 use io::{InputPort, OutputPort};
 use std::os::raw::c_int;
 use types::{Error, PortMidiDeviceId, Result};
+use vdevice::VirtualDevice;
 
 /// The PortMidi base struct.
 /// Initializes PortMidi on creation and terminates it on drop.
@@ -118,7 +118,6 @@ impl PortMidi {
     pub fn create_virtual_output(&self, name: &str) -> Result<VirtualDevice> {
         VirtualDevice::new(name, Direction::Output)
     }
-
 }
 impl Drop for PortMidi {
     fn drop(&mut self) {

--- a/src/context.rs
+++ b/src/context.rs
@@ -114,7 +114,8 @@ impl Drop for PortMidi {
         if !self.virtual_devs.is_empty() {
             for id in self.virtual_devs.iter() {
                 Result::from(unsafe { ffi::Pm_DeleteVirtualDevice(*id) })
-                    .map_err(|err| println!("Could not terminate: {}", err)).unwrap();
+                    .map_err(|err| println!("Could not delete virtual device: {}", err))
+                    .unwrap();
 	    }
         }
 

--- a/src/ffi/functions.rs
+++ b/src/ffi/functions.rs
@@ -36,6 +36,17 @@ extern "C" {
                          time_info: *const c_void,
                          latency: i32)
                          -> PmError;
+    pub fn Pm_CreateVirtualInput(
+        name: *const c_char,
+        interf: *const c_char,
+        deviceInfo: *const c_void,
+    ) -> PmError;
+    pub fn Pm_CreateVirtualOutput(
+        name: *const c_char,
+        interf: *const c_char,
+        deviceInfo: *const c_void,
+    ) -> PmError;
+    pub fn Pm_DeleteVirtualDevice(device: PmDeviceId) -> PmError;
     pub fn Pm_Read(stream: *const PortMidiStream, buffer: *mut PmEvent, length: c_int) -> c_int;
     fn Pm_Abort(stream: *const PortMidiStream) -> PmError;
     pub fn Pm_Close(stream: *const PortMidiStream) -> PmError;

--- a/src/ffi/functions.rs
+++ b/src/ffi/functions.rs
@@ -6,8 +6,8 @@
 //          MIT license (LICENSE-MIT or http://opensource.org/licenses/MIT).
 // This file may not be copied, modified, or distributed except according to those terms.
 
-use std::os::raw::{c_char, c_void, c_int, c_uchar};
 use ffi::types::*;
+use std::os::raw::{c_char, c_int, c_uchar, c_void};
 
 #[allow(dead_code)]
 #[link(name = "portmidi")]
@@ -21,21 +21,23 @@ extern "C" {
     pub fn Pm_GetDefaultInputDeviceID() -> PmDeviceId;
     pub fn Pm_GetDefaultOutputDeviceID() -> PmDeviceId;
     pub fn Pm_GetDeviceInfo(id: PmDeviceId) -> *const PmDeviceInfo;
-    pub fn Pm_OpenInput(stream: *const *const PortMidiStream,
-                        inputDevice: PmDeviceId,
-                        inputDriverInfo: *const c_void,
-                        bufferSize: i32,
-                        time_proc: *const c_void,
-                        time_info: *const c_void)
-                        -> PmError;
-    pub fn Pm_OpenOutput(stream: *const *const PortMidiStream,
-                         outputDevice: PmDeviceId,
-                         inputDriverInfo: *const c_void,
-                         bufferSize: i32,
-                         time_proc: *const c_void,
-                         time_info: *const c_void,
-                         latency: i32)
-                         -> PmError;
+    pub fn Pm_OpenInput(
+        stream: *const *const PortMidiStream,
+        inputDevice: PmDeviceId,
+        inputDriverInfo: *const c_void,
+        bufferSize: i32,
+        time_proc: *const c_void,
+        time_info: *const c_void,
+    ) -> PmError;
+    pub fn Pm_OpenOutput(
+        stream: *const *const PortMidiStream,
+        outputDevice: PmDeviceId,
+        inputDriverInfo: *const c_void,
+        bufferSize: i32,
+        time_proc: *const c_void,
+        time_info: *const c_void,
+        latency: i32,
+    ) -> PmError;
     pub fn Pm_CreateVirtualInput(
         name: *const c_char,
         interf: *const c_char,
@@ -51,16 +53,19 @@ extern "C" {
     fn Pm_Abort(stream: *const PortMidiStream) -> PmError;
     pub fn Pm_Close(stream: *const PortMidiStream) -> PmError;
     pub fn Pm_Poll(stream: *const PortMidiStream) -> PmError;
-    pub fn Pm_Write(stream: *const PortMidiStream,
-                    buffer: *const PmEvent,
-                    length: c_int)
-                    -> PmError;
-    pub fn Pm_WriteShort(stream: *const PortMidiStream,
-                         timestamp: PmTimestamp,
-                         message: PmMessage)
-                         -> PmError;
-    pub fn Pm_WriteSysEx(stream: *const PortMidiStream,
-                         when: PmTimestamp,
-                         msg: *const c_uchar)
-                         -> PmError;
+    pub fn Pm_Write(
+        stream: *const PortMidiStream,
+        buffer: *const PmEvent,
+        length: c_int,
+    ) -> PmError;
+    pub fn Pm_WriteShort(
+        stream: *const PortMidiStream,
+        timestamp: PmTimestamp,
+        message: PmMessage,
+    ) -> PmError;
+    pub fn Pm_WriteSysEx(
+        stream: *const PortMidiStream,
+        when: PmTimestamp,
+        msg: *const c_uchar,
+    ) -> PmError;
 }

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -1,16 +1,14 @@
-mod types;
 mod functions;
-pub use self::types::*;
+mod types;
 pub use self::functions::*;
+pub use self::types::*;
 
-use std::os::raw::c_char;
 use std::ffi::CStr;
+use std::os::raw::c_char;
 
 pub fn ptr_to_string(str_ptr: *const c_char) -> Option<String> {
     if !str_ptr.is_null() {
-        match unsafe { CStr::from_ptr(str_ptr) }
-                  .to_str()
-                  .ok() {
+        match unsafe { CStr::from_ptr(str_ptr) }.to_str().ok() {
             Some(str_slice) => Some(str_slice.to_owned()),
             None => None,
         }

--- a/src/ffi/types.rs
+++ b/src/ffi/types.rs
@@ -93,6 +93,7 @@ impl MaybeError<c_int> for PmError {
     fn try_from(err_code: c_int) -> Result<c_int, PmError> {
         match err_code {
             -10_000..=-9992 | 0 => unsafe { Err(mem::transmute(err_code)) },
+            -9989 => Err(PmError::PmInvalidDeviceId),
             _ => Ok(err_code),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,8 @@
 //          Apache License, Version 2.0, (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0)
 //          MIT license (LICENSE-MIT or http://opensource.org/licenses/MIT).
 // This file may not be copied, modified, or distributed except according to those terms.
-mod ffi;
 mod device;
+mod ffi;
 pub use device::*;
 mod io;
 pub use io::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,8 @@
 //          MIT license (LICENSE-MIT or http://opensource.org/licenses/MIT).
 // This file may not be copied, modified, or distributed except according to those terms.
 mod device;
-mod vdevice;
 mod ffi;
+mod vdevice;
 pub use device::*;
 pub use vdevice::VirtualDevice;
 mod io;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,10 @@
 //          MIT license (LICENSE-MIT or http://opensource.org/licenses/MIT).
 // This file may not be copied, modified, or distributed except according to those terms.
 mod device;
+mod vdevice;
 mod ffi;
 pub use device::*;
+pub use vdevice::VirtualDevice;
 mod io;
 pub use io::*;
 

--- a/src/vdevice.rs
+++ b/src/vdevice.rs
@@ -1,11 +1,10 @@
+use device::{DeviceInfo, Direction};
 use ffi;
-use types::*;
-use device::{Direction, DeviceInfo};
-use std::ptr;
+use ffi::MaybeError;
 use std::ffi::CString;
 use std::os::raw::c_int;
-use ffi::MaybeError;
-
+use std::ptr;
+use types::*;
 
 #[derive(Clone, Debug)]
 pub struct VirtualDevice {
@@ -13,16 +12,18 @@ pub struct VirtualDevice {
 }
 
 impl VirtualDevice {
-
     /// Creates a virtual input/output device depending on direction argument.
-    /// Returns the device info of the created device or an Error. 
+    /// Returns the device info of the created device or an Error.
     pub fn new(name: &str, direction: Direction) -> Result<Self> {
-
         let c_string = CString::new(name).unwrap();
 
         let id = match direction {
-            Direction::Input => unsafe { ffi::Pm_CreateVirtualInput(c_string.as_ptr(), ptr::null(), ptr::null()) },
-            Direction::Output => unsafe { ffi::Pm_CreateVirtualOutput(c_string.as_ptr(), ptr::null(), ptr::null()) },
+            Direction::Input => unsafe {
+                ffi::Pm_CreateVirtualInput(c_string.as_ptr(), ptr::null(), ptr::null())
+            },
+            Direction::Output => unsafe {
+                ffi::Pm_CreateVirtualOutput(c_string.as_ptr(), ptr::null(), ptr::null())
+            },
         };
 
         let id = match ffi::PmError::try_from(id as c_int) {
@@ -38,23 +39,30 @@ impl VirtualDevice {
 
         let info = DeviceInfo::new(id)?;
 
-        Ok(VirtualDevice {
-            info,
-        })
+        Ok(VirtualDevice { info })
     }
 
-    pub fn id(&self) -> PortMidiDeviceId { self.info.id() }
+    pub fn id(&self) -> PortMidiDeviceId {
+        self.info.id()
+    }
 
-    pub fn name(&self) -> &str { self.info.name() }
+    pub fn name(&self) -> &str {
+        self.info.name()
+    }
 
-    pub fn is_input(&self) -> bool { self.info.is_input() }
+    pub fn is_input(&self) -> bool {
+        self.info.is_input()
+    }
 
-    pub fn is_output(&self) -> bool { self.info.is_output() }
+    pub fn is_output(&self) -> bool {
+        self.info.is_output()
+    }
 }
 
 impl Drop for VirtualDevice {
-    fn drop(&mut self)  {
+    fn drop(&mut self) {
         Result::from(unsafe { ffi::Pm_DeleteVirtualDevice(self.id()) })
-            .map_err(|err| println!("Error deleting virtual device: {}", err)).unwrap();
+            .map_err(|err| println!("Error deleting virtual device: {}", err))
+            .unwrap();
     }
 }

--- a/src/vdevice.rs
+++ b/src/vdevice.rs
@@ -50,11 +50,6 @@ impl VirtualDevice {
     pub fn is_input(&self) -> bool { self.info.is_input() }
 
     pub fn is_output(&self) -> bool { self.info.is_output() }
-
-    pub fn devinfo(&self) -> &DeviceInfo {
-        &self.info
-    }
-
 }
 
 impl Drop for VirtualDevice {

--- a/src/vdevice.rs
+++ b/src/vdevice.rs
@@ -1,0 +1,65 @@
+use ffi;
+use types::*;
+use device::{Direction, DeviceInfo};
+use std::ptr;
+use std::ffi::CString;
+use std::os::raw::c_int;
+use ffi::MaybeError;
+
+
+#[derive(Clone, Debug)]
+pub struct VirtualDevice {
+    info: DeviceInfo,
+}
+
+impl VirtualDevice {
+
+    /// Creates a virtual input/output device depending on direction argument.
+    /// Returns the device info of the created device or an Error. 
+    pub fn new(name: &str, direction: Direction) -> Result<Self> {
+
+        let c_string = CString::new(name).unwrap();
+
+        let id = match direction {
+            Direction::Input => unsafe { ffi::Pm_CreateVirtualInput(c_string.as_ptr(), ptr::null(), ptr::null()) },
+            Direction::Output => unsafe { ffi::Pm_CreateVirtualOutput(c_string.as_ptr(), ptr::null(), ptr::null()) },
+        };
+
+        let id = match ffi::PmError::try_from(id as c_int) {
+            Err(ffi::PmError::PmNoError) => None,
+            Err(ffi::PmError::PmInvalidDeviceId) => {
+                panic!("Device name \"{}\" already exists or is invalid!", name)
+            }
+            Err(err) => return Err(Error::PortMidi(err)),
+            Ok(id) => Some(id),
+        };
+
+        let id: PortMidiDeviceId = id.unwrap();
+
+        let info = DeviceInfo::new(id)?;
+
+        Ok(VirtualDevice {
+            info,
+        })
+    }
+
+    pub fn id(&self) -> PortMidiDeviceId { self.info.id() }
+
+    pub fn name(&self) -> &str { self.info.name() }
+
+    pub fn is_input(&self) -> bool { self.info.is_input() }
+
+    pub fn is_output(&self) -> bool { self.info.is_output() }
+
+    pub fn devinfo(&self) -> &DeviceInfo {
+        &self.info
+    }
+
+}
+
+impl Drop for VirtualDevice {
+    fn drop(&mut self)  {
+        Result::from(unsafe { ffi::Pm_DeleteVirtualDevice(self.id()) })
+            .map_err(|err| println!("Error deleting virtual device: {}", err)).unwrap();
+    }
+}

--- a/tests/portmidi.rs
+++ b/tests/portmidi.rs
@@ -28,8 +28,8 @@ fn test_main() {
 	// creating virtual ports on windows not possible that way (only through drivers)
 	if ! cfg!(windows) {
             assert_eq!(context.virtual_device_count(), 0);
-            let v_in = context.create_virtual_input("Virt in".into()).unwrap();
-            context.create_virtual_output("Virt out".into()).unwrap();
+            let v_in = context.create_virtual_input("Virt in").unwrap();
+            context.create_virtual_output("Virt out").unwrap();
             assert_eq!(context.virtual_device_count(), 2);
 	    context.delete_virtual_device(v_in.id()).unwrap();
             assert_eq!(context.virtual_device_count(), 1);

--- a/tests/portmidi.rs
+++ b/tests/portmidi.rs
@@ -24,6 +24,7 @@ fn test_main() {
         assert!(context.default_input_device_id().is_ok());
         assert!(context.default_output_device_id().is_ok());
         assert!(context.devices().unwrap().len() > 0);
+        assert!(context.virtual_device_count() == 0);
         let mut in_port = context.default_input_port(1024).unwrap();
         let mut out_port = context.default_output_port(1024).unwrap();
         match in_port.poll() {

--- a/tests/portmidi.rs
+++ b/tests/portmidi.rs
@@ -24,7 +24,17 @@ fn test_main() {
         assert!(context.default_input_device_id().is_ok());
         assert!(context.default_output_device_id().is_ok());
         assert!(context.devices().unwrap().len() > 0);
-        assert!(context.virtual_device_count() == 0);
+
+	// creating virtual ports on windows not possible that way (only through drivers)
+	if ! cfg!(windows) {
+            assert_eq!(context.virtual_device_count(), 0);
+            let v_in = context.create_virtual_input("Virt in".into()).unwrap();
+            context.create_virtual_output("Virt out".into()).unwrap();
+            assert_eq!(context.virtual_device_count(), 2);
+	    context.delete_virtual_device(v_in.id()).unwrap();
+            assert_eq!(context.virtual_device_count(), 1);
+        }
+
         let mut in_port = context.default_input_port(1024).unwrap();
         let mut out_port = context.default_output_port(1024).unwrap();
         match in_port.poll() {

--- a/tests/portmidi.rs
+++ b/tests/portmidi.rs
@@ -25,13 +25,13 @@ fn test_main() {
         assert!(context.default_output_device_id().is_ok());
         assert!(context.devices().unwrap().len() > 0);
 
-	// creating virtual ports on windows not possible that way (only through drivers)
-	if ! cfg!(windows) {
+        // creating virtual ports on windows not possible that way (only through drivers)
+        if !cfg!(windows) {
             assert_eq!(context.virtual_device_count(), 0);
             let v_in = context.create_virtual_input("Virt in").unwrap();
             context.create_virtual_output("Virt out").unwrap();
             assert_eq!(context.virtual_device_count(), 2);
-	    context.delete_virtual_device(v_in.id()).unwrap();
+            context.delete_virtual_device(v_in.id()).unwrap();
             assert_eq!(context.virtual_device_count(), 1);
         }
 
@@ -46,18 +46,20 @@ fn test_main() {
             Ok(None) => println!("test_main) no midi event available"),
             Err(err) => println!("test_main) read error: {}", err),
         };
-        let msgs = vec![portmidi::MidiMessage {
-                            status: 0x90,
-                            data1: 60,
-                            data2: 127,
-                            data3: 0,
-                        },
-                        portmidi::MidiMessage {
-                            status: 0x80,
-                            data1: 60,
-                            data2: 0,
-                            data3: 0,
-                        }];
+        let msgs = vec![
+            portmidi::MidiMessage {
+                status: 0x90,
+                data1: 60,
+                data2: 127,
+                data3: 0,
+            },
+            portmidi::MidiMessage {
+                status: 0x80,
+                data1: 60,
+                data2: 0,
+                data3: 0,
+            },
+        ];
         match out_port.write_events(msgs) {
             Ok(_) => println!("test_main) successfully wrote midi events"),
             Err(err) => println!("test_main) write error: {}", err),
@@ -89,18 +91,20 @@ fn test_threads() {
         });
         let writer = thread::spawn(move || {
             let mut out_port = context.default_output_port(BUF_LEN).unwrap();
-            let msgs = vec![portmidi::MidiMessage {
-                                status: 0x90,
-                                data1: 60,
-                                data2: 127,
-                                data3: 0,
-                            },
-                            portmidi::MidiMessage {
-                                status: 0x80,
-                                data1: 60,
-                                data2: 0,
-                                data3: 0,
-                            }];
+            let msgs = vec![
+                portmidi::MidiMessage {
+                    status: 0x90,
+                    data1: 60,
+                    data2: 127,
+                    data3: 0,
+                },
+                portmidi::MidiMessage {
+                    status: 0x80,
+                    data1: 60,
+                    data2: 0,
+                    data3: 0,
+                },
+            ];
             match out_port.write_events(msgs) {
                 Ok(_) => println!("test_threads) successfully wrote midi events"),
                 Err(err) => println!("test_threads) write error: {}", err),


### PR DESCRIPTION
As stated above I included the functions to create and delete virtual input and output ports into the library.

I wrapped these functions in the `PortMidi` struct implementation and added a mutex with a vector to hold the
created virtual devices. This way all virtual devices automatically get freed when the `PortMidi` struct drops (added logic in the drop trait implementation) and it is easily possible to keep an overview of all virtual devices (requesting a list of virtual devices and the number of virtual devices also possible now).

I also added an example and some test calls to the `test_main` function.

I hope the code is not too messy. I'm relatively new to Rust and it might be that I didn't always find the most efficient solution :'D
